### PR TITLE
Fix for Android versions and receiving intents

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "info.nightscout.client"
-        minSdkVersion 22
+        minSdkVersion 19
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,7 +72,7 @@
         <receiver
             android:name=".receivers.DBAccessReceiver"
             android:enabled="true"
-            android:exported="false"
+            android:exported="true"
             android:process=":mainProcess">
             <intent-filter>
                 <action android:name="info.nightscout.client.DBACCESS" />


### PR DESCRIPTION
1) build.gradle fix to allow running on android 4.4 and above
2) AndroidManifest.xml fix to allow receiving of intents

The default android target version is 22, I have changed and tested this on android version 4.4 (api v19) - previously the apk could not be installed.

The default android manifest does not export the receiver intent making it impossible to receive intents from another app (eg beyond the internal tests) - exporting that fixes the problem.

xDrip+ now syncs treatments in both directions with NSClient-Android