### PR TITLE
Improve privacy with option

### DIFF
--- a/app/src/main/java/info/nightscout/client/MainApp.java
+++ b/app/src/main/java/info/nightscout/client/MainApp.java
@@ -1,6 +1,7 @@
 package info.nightscout.client;
 
 import android.app.Application;
+import android.preference.PreferenceManager;
 
 import com.crashlytics.android.Crashlytics;
 import com.squareup.otto.Bus;
@@ -34,7 +35,9 @@ public class MainApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        Fabric.with(this, new Crashlytics());
+        if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean("enable_crashlytics", true)) {
+            Fabric.with(this, new Crashlytics());
+        }
         sInstance = this;
 
         sBus = new Bus(ThreadEnforcer.ANY);

--- a/app/src/main/java/info/nightscout/client/PreferencesActivity.java
+++ b/app/src/main/java/info/nightscout/client/PreferencesActivity.java
@@ -3,9 +3,11 @@ package info.nightscout.client;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
+import android.widget.Toast;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,6 +26,7 @@ public class PreferencesActivity extends PreferenceActivity implements SharedPre
         super.onCreate(savedInstanceState);
         getFragmentManager().beginTransaction().replace(android.R.id.content, new MyPreferenceFragment()).commit();
         PreferenceManager.getDefaultSharedPreferences(this).registerOnSharedPreferenceChangeListener(this);
+
     }
 
     @Override
@@ -46,6 +49,17 @@ public class PreferencesActivity extends PreferenceActivity implements SharedPre
         {
             super.onCreate(savedInstanceState);
             addPreferencesFromResource(R.xml.pref_ns);
+
+            final Preference crash_reports = findPreference("enable_crashlytics");
+            crash_reports.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    Toast.makeText(preference.getContext(),
+                            "Crash Setting takes effect on next restart", Toast.LENGTH_LONG).show();
+                    return true;
+                }
+            });
+
         }
     }
 

--- a/app/src/main/res/xml/pref_ns.xml
+++ b/app/src/main/res/xml/pref_ns.xml
@@ -68,6 +68,11 @@
             android:defaultValue="400"
             android:inputType="numberDecimal">
         </EditTextPreference>
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="enable_crashlytics"
+            android:summary="Send crash errors to developer"
+            android:title="Automatic Crash Reporting" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Fabric/Crashlytics is very useful for automated crash reporting, but its feature set is quite extensive and has privacy implications. Some users may prefer to have this as an option. 

This patch adds a preference option allowing Crashlytics to be disabled (default is enabled) - Settings change would take effect next time the app is restarted.