### PR TITLE
Threading / reliability fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity
             android:name=".PreferencesActivity"
             android:label="@string/action_preferences"
+            android:launchMode="singleTop"
             android:parentActivityName=".MainActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/info/nightscout/client/MainActivity.java
+++ b/app/src/main/java/info/nightscout/client/MainActivity.java
@@ -70,8 +70,12 @@ public class MainActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
-        getSupportActionBar().setDisplayShowHomeEnabled(true);
-        getSupportActionBar().setIcon(R.mipmap.ic_launcher);
+        try {
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+            getSupportActionBar().setIcon(R.mipmap.ic_launcher);
+        } catch (NullPointerException e) {
+            // no action
+        }
 
         if(handler==null) {
             handlerThread = new HandlerThread(MainActivity.class.getSimpleName() + "Handler");
@@ -280,11 +284,15 @@ public class MainActivity extends AppCompatActivity {
 
     @Subscribe
     public void onStatusEvent(final EventRestart e) {
-        SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(MainApp.instance().getApplicationContext());
-        String web = SP.getString("ns_url", "");
-        TextView viewWeb = ((TextView) findViewById(R.id.nsWeb));
-        viewWeb.setText( Html.fromHtml("<a href=" + web + ">" + web + "</a>"));
-        viewWeb.setMovementMethod(LinkMovementMethod.getInstance());
+        final SharedPreferences SP = PreferenceManager.getDefaultSharedPreferences(MainApp.instance().getApplicationContext());
+        final String web = SP.getString("ns_url", "");
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                TextView viewWeb = ((TextView) findViewById(R.id.nsWeb));
+                viewWeb.setText(Html.fromHtml("<a href=" + web + ">" + web + "</a>"));
+                viewWeb.setMovementMethod(LinkMovementMethod.getInstance());
+            }});
     }
 
     private boolean haveNetworkConnection() {

--- a/app/src/main/java/info/nightscout/client/MainActivity.java
+++ b/app/src/main/java/info/nightscout/client/MainActivity.java
@@ -98,21 +98,16 @@ public class MainActivity extends AppCompatActivity {
         logger.setLevel(Level.DEBUG);
         logger.setAdditive(true);
 
-        new Thread() {
+        handler.post(new Runnable() {
             @Override
             public void run() {
                 startService(new Intent(getApplicationContext(), ServiceNS.class));
                 registerBus();
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        setupAlarmManager();
-                        log.debug("ALARMMAN setup");
-                    }
-                });
+                setupAlarmManager();
+                log.debug("ALARMMAN setup");
                 onStatusEvent(new EventRestart());
             }
-        }.start();
+        });
 
         boolean autoscrollEnabled = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("nsAutoScroll", true);
         switchAutoscroll.setChecked(autoscrollEnabled);

--- a/app/src/main/java/info/nightscout/client/MainActivity.java
+++ b/app/src/main/java/info/nightscout/client/MainActivity.java
@@ -70,6 +70,9 @@ public class MainActivity extends AppCompatActivity {
             e.printStackTrace();
         }
 
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        getSupportActionBar().setIcon(R.mipmap.ic_launcher);
+
         if(handler==null) {
             handlerThread = new HandlerThread(MainActivity.class.getSimpleName() + "Handler");
             handlerThread.start();
@@ -91,16 +94,21 @@ public class MainActivity extends AppCompatActivity {
         logger.setLevel(Level.DEBUG);
         logger.setAdditive(true);
 
-        startService(new Intent(getApplicationContext(), ServiceNS.class));
-        registerBus();
-        handler.post(new Runnable() {
+        new Thread() {
             @Override
             public void run() {
-                setupAlarmManager();
-                log.debug("ALARMMAN setup");
+                startService(new Intent(getApplicationContext(), ServiceNS.class));
+                registerBus();
+                handler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        setupAlarmManager();
+                        log.debug("ALARMMAN setup");
+                    }
+                });
+                onStatusEvent(new EventRestart());
             }
-        });
-        onStatusEvent(new EventRestart());
+        }.start();
 
         boolean autoscrollEnabled = PreferenceManager.getDefaultSharedPreferences(getApplicationContext()).getBoolean("nsAutoScroll", true);
         switchAutoscroll.setChecked(autoscrollEnabled);

--- a/app/src/main/java/info/nightscout/client/MainApp.java
+++ b/app/src/main/java/info/nightscout/client/MainApp.java
@@ -1,6 +1,8 @@
 package info.nightscout.client;
 
 import android.app.Application;
+import android.content.Context;
+import android.os.PowerManager;
 import android.preference.PreferenceManager;
 
 import com.crashlytics.android.Crashlytics;
@@ -57,5 +59,17 @@ public class MainApp extends Application {
 
     public static void setNsProfile(NSProfile profile) { nsProfile = profile; }
     public static NSProfile getNsProfile() { return nsProfile; }
+
+    public static PowerManager.WakeLock getWakeLock(final String name, int millis) {
+        final PowerManager pm = (PowerManager) instance().getSystemService(Context.POWER_SERVICE);
+        PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, name);
+        wl.acquire(millis);
+        return wl;
+    }
+
+    public static void releaseWakeLock(PowerManager.WakeLock wl) {
+        if (wl.isHeld()) wl.release();
+    }
+
 
 }

--- a/app/src/main/java/info/nightscout/client/receivers/ReceiverKeepAlive.java
+++ b/app/src/main/java/info/nightscout/client/receivers/ReceiverKeepAlive.java
@@ -17,30 +17,40 @@ import info.nightscout.client.services.ServiceNS;
 
 public class ReceiverKeepAlive extends WakefulBroadcastReceiver {
     private static Logger log = LoggerFactory.getLogger(ReceiverKeepAlive.class);
+    private static final long tenMinutesInMs = 10 * 60 * 1000l;
+    private static final long thirtyMinutesInMs = 10 * 60 * 1000l;
 
     @Override
-	public void onReceive(Context context, Intent intent) {
+	public void onReceive(final Context context, final Intent intent) {
 
-         startWakefulService(context, new Intent(context, ServiceNS.class)
-                .setAction(intent.getAction())
-                .putExtras(intent));
-        //log.debug("KEEPALIVE started ServiceNS " + intent);
-        if (Config.detailedLog) log.debug("KEEPALIVE");
-        NSClient nsClient = MainApp.getNSClient();
-        if (nsClient != null) {
-            long tenMinutesInMs = 10 * 60 * 1000l;
-            if (Config.detailedLog)
-                log.debug("KEEPALIVE last reception " + nsClient.lastReception.toString());
-            if (new Date().getTime() > nsClient.lastReception.getTime() + tenMinutesInMs) {
-                log.debug("KEEPALIVE no reception for 10 min");
-                nsClient.doPing();
-            }
+        new Thread() {
+            @Override
+            public void run() {
 
-            if (nsClient.forcerestart) {
-                MainApp.bus().post(new EventRestart());
+                startWakefulService(context, new Intent(context, ServiceNS.class)
+                        .setAction(intent.getAction())
+                        .putExtras(intent));
+                //log.debug("KEEPALIVE started ServiceNS " + intent);
+                if (Config.detailedLog) log.debug("KEEPALIVE");
+                NSClient nsClient = MainApp.getNSClient();
+                if (nsClient != null) {
+                    if (Config.detailedLog)
+                        log.debug("KEEPALIVE last reception " + nsClient.lastReception.toString());
+                    if (new Date().getTime() > nsClient.lastReception.getTime() + thirtyMinutesInMs) {
+                        log.debug("KEEPALIVE no reception for 30 min - force restart");
+                        MainApp.bus().post(new EventRestart());
+                    } else if (new Date().getTime() > nsClient.lastReception.getTime() + tenMinutesInMs) {
+                        log.debug("KEEPALIVE no reception for 10 min");
+                        nsClient.doPing();
+                    }
+
+                    if (nsClient.forcerestart) {
+                        MainApp.bus().post(new EventRestart());
+                    }
+                }
+                completeWakefulIntent(intent);
             }
-        }
-        completeWakefulIntent(intent);
+        }.start();
     }
 
 }

--- a/app/src/main/java/info/nightscout/client/receivers/ReceiverKeepAlive.java
+++ b/app/src/main/java/info/nightscout/client/receivers/ReceiverKeepAlive.java
@@ -2,6 +2,7 @@ package info.nightscout.client.receivers;
 
 import android.content.Context;
 import android.content.Intent;
+import android.preference.PreferenceManager;
 import android.support.v4.content.WakefulBroadcastReceiver;
 
 import org.slf4j.Logger;
@@ -37,8 +38,11 @@ public class ReceiverKeepAlive extends WakefulBroadcastReceiver {
                     if (Config.detailedLog)
                         log.debug("KEEPALIVE last reception " + nsClient.lastReception.toString());
                     if (new Date().getTime() > nsClient.lastReception.getTime() + thirtyMinutesInMs) {
-                        log.debug("KEEPALIVE no reception for 30 min - force restart");
-                        MainApp.bus().post(new EventRestart());
+                        if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean("ns_enable", false))
+                        {
+                            log.debug("KEEPALIVE no reception for 30 min - force restart");
+                            MainApp.bus().post(new EventRestart());
+                        }
                     } else if (new Date().getTime() > nsClient.lastReception.getTime() + tenMinutesInMs) {
                         log.debug("KEEPALIVE no reception for 10 min");
                         nsClient.doPing();

--- a/app/src/main/java/info/nightscout/client/services/ServiceNS.java
+++ b/app/src/main/java/info/nightscout/client/services/ServiceNS.java
@@ -125,7 +125,7 @@ public class ServiceNS extends Service {
     }
 
     @Subscribe
-    public void onStatusEvent(final EventRestart e) {
+    public synchronized void onStatusEvent(final EventRestart e) {
         if (restartingService) {
             log.debug("Restarting of WS Client already in progress");
             return;


### PR DESCRIPTION
Recently I have had problems with NSClient where it would lock up. Symptoms might include android saying the process had frozen and offering to kill it or the gui window being totally blank when opened. Sync with Nightscout would stop during these times.

This PR is my attempt a fixing these issues. Using this version they no longer occur in the 60 hours of testing I have done so far.  It may be that further changes need to be made but I think this is a significant improvement and I would welcome other people trying it to confirm it also works reliably for them.

The changes include:

- runOnUIthread() method to update UI elements from background threads
- Service setup being done on background thread within MainActivity
- NSClient work being done on background thread
- Causing a full restart if no data received in >30 minutes
- Additional timed Wakelock
- Cosmetic addition of NightScout icon to MainActivity title bar.
- Prevention of duplicate preference activities appearing

Please let me know what you think?